### PR TITLE
trying to fix line numbers bug by adding extra tabs

### DIFF
--- a/content/learning-path/6/module-2.ar.md
+++ b/content/learning-path/6/module-2.ar.md
@@ -183,7 +183,7 @@ It is a recommended practice to not include sensitive information in GET paramet
 
   keep = ['select', 'where', 'from', 'and', 'script', 'on', 'src', '../', '<', '>']
   output = ''
-
+  
   i = 0
   while i < len(target):
   	matched = False

--- a/content/learning-path/6/module-2.en.md
+++ b/content/learning-path/6/module-2.en.md
@@ -182,10 +182,10 @@ It is a recommended practice to not include sensitive information in GET paramet
 
   {{< highlight python "linenos=table" >}}
   import re
-
+  
   keep = \['select', 'where', 'from', 'and', 'script', 'on', 'src', '../', '<', '>']
   output = ''
-
+  
   i = 0
   while i < len(target):
   	matched = False

--- a/content/learning-path/6/module-2.es.md
+++ b/content/learning-path/6/module-2.es.md
@@ -180,10 +180,10 @@ Es una práctica recomendada no incluir información confidencial en los paráme
 
   {{< highlight python "linenos=table" >}}
   import re
-
+  
   keep = ['select', 'where', 'from', 'and', 'script', 'on', 'src', '../', '<', '>']
   output = ''
-
+  
   i = 0
   while i < len(target):
   	matched = False

--- a/content/learning-path/6/module-2.fr.md
+++ b/content/learning-path/6/module-2.fr.md
@@ -182,10 +182,10 @@ Il est recommandé de ne pas inclure d'informations sensibles dans les paramètr
 
   {{< highlight python "linenos=table" >}}
   import re
-
+  
   keep = ['select', 'where', 'from', 'and', 'script', 'on', 'src', '../', '<', '>']
   output = ''
-
+  
   i = 0
   while i < len(target):
   	matched = False


### PR DESCRIPTION
There's a small bug in Hugo where only the first 23 lines of a 25 line code are labeled. Trying to fix it by adding tabs to lines 2 and 5 of the pasted code